### PR TITLE
Fix code scanning alert no. 1: Log entries created from user input

### DIFF
--- a/Controllers/GoatsController.cs
+++ b/Controllers/GoatsController.cs
@@ -118,7 +118,8 @@ public class GoatsController : ControllerBase
 
         // var id = Request.Query["id"];
 
-        _logger.LogInformation($"GetCustomers called with id {id}");
+        var sanitizedId = id.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+        _logger.LogInformation($"GetCustomers called with id {sanitizedId}");
 
         connection.Open();
 


### PR DESCRIPTION
Fixes [https://github.com/Algvaldivia/dotnet-goat-api/security/code-scanning/1](https://github.com/Algvaldivia/dotnet-goat-api/security/code-scanning/1)

To fix the problem, we need to sanitize the user input before logging it. Specifically, we should remove any newline characters from the `id` parameter to prevent log forging. This can be done using the `String.Replace` method to replace newline characters with an empty string. This change should be made in the `GetCustomerByIdInTheWrongWay` method in the `Controllers/GoatsController.cs` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
