### PR TITLE
Fix code scanning alert no. 2: SQL query built from user-controlled sources

### DIFF
--- a/Controllers/GoatsController.cs
+++ b/Controllers/GoatsController.cs
@@ -122,7 +122,8 @@ public class GoatsController : ControllerBase
 
         connection.Open();
 
-        using var command = new SqlCommand($"SELECT * FROM Customers WHERE Id={id}", connection);
+        using var command = new SqlCommand("SELECT * FROM Customers WHERE Id=@id", connection);
+        command.Parameters.AddWithValue("@id", id);
 
         using var reader = command.ExecuteReader();
         while (reader.Read())


### PR DESCRIPTION
Fixes [https://github.com/Algvaldivia/dotnet-goat-api/security/code-scanning/2](https://github.com/Algvaldivia/dotnet-goat-api/security/code-scanning/2)

To fix the SQL injection vulnerability, we should use parameterized queries instead of string interpolation to construct the SQL query. This involves using `SqlParameter` objects to safely pass user input to the SQL command. This approach ensures that any special characters in the user input are properly escaped, preventing SQL injection attacks.

**Steps to fix the problem:**
1. Replace the string interpolation in the SQL query with a parameterized query.
2. Add a `SqlParameter` object to the `SqlCommand` to safely pass the `id` parameter.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
