### PR TITLE
Fix code scanning alert no. 1: Log entries created from user input

### DIFF
--- a/Controllers/GoatsController.cs
+++ b/Controllers/GoatsController.cs
@@ -118,7 +118,8 @@ public class GoatsController : ControllerBase
 
         // var id = Request.Query["id"];
 
-        _logger.LogInformation($"GetCustomers called with id {id}");
+        var sanitizedId = id.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+        _logger.LogInformation($"GetCustomers called with id {sanitizedId}");
 
         connection.Open();
 


### PR DESCRIPTION
Fixes [https://github.com/Algvaldivia/dotnet-goat-api/security/code-scanning/1](https://github.com/Algvaldivia/dotnet-goat-api/security/code-scanning/1)

To fix the problem, we need to sanitize the user input before logging it. Since the log entries are likely to be displayed as plain text, we should remove any new line characters from the user input to prevent log forging. This can be done using the `String.Replace` method to replace new line characters with an empty string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
